### PR TITLE
json_encode invalid response

### DIFF
--- a/src/LE_ACME2/Exception/InvalidResponse.php
+++ b/src/LE_ACME2/Exception/InvalidResponse.php
@@ -7,6 +7,6 @@ use LE_ACME2\Connector\RawResponse;
 class InvalidResponse extends AbstractException {
 
     public function __construct(RawResponse $raw) {
-        parent::__construct("Invalid response received: " . var_export($raw, true));
+	    parent::__construct(json_encode(var_export($raw, true)));
     }
 }


### PR DESCRIPTION
Hi @fbett, 

I encountered some issues when I wanted to parse and output the response errors when an error is thrown. If I json_encode the response, I can easily read is as an object/array. 

Please take a look at the proposed change and let me know what you think. 